### PR TITLE
Add NuGet.config for Xamarin.Forms Nightly feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,3 @@ ApiConstants.cs
 Xappy/.vscode/settings.json
 .idea
 global.json
-NuGet.Config

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Xamarin.Forms Nightly" value="https://aka.ms/xf-ci/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Forms/wiki/Nightly-Builds

Since this repo uses Xamarin.Forms nightly packages, you should include this `NuGet.config` so that anybody can clone this repo and build it.

After this change, I could build this on a new PC with no custom NuGet feeds setup.