### PR TITLE
Two tweaks to fix two navigational crashes in Android. 

### DIFF
--- a/Xappy/Xappy/Content/About/IndexPage.xaml
+++ b/Xappy/Xappy/Content/About/IndexPage.xaml
@@ -2,11 +2,11 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:Xappy.About.ViewModels"
-             xmlns:global="clr-namespace:Xappy.Domain.Global"             
+             xmlns:global="clr-namespace:Xappy.Domain.Global"
              x:Class="Xappy.About.IndexPage"
              Title="About"
              Shell.TabBarIsVisible="false"
-             BackgroundColor="{StaticResource ColorAppBackground}">
+             BackgroundColor="{DynamicResource backgroundColor}">
     <ContentPage.Resources>
         <ResourceDictionary>
             <DataTemplate x:Key="HeaderTemplate">
@@ -26,7 +26,7 @@
                 <ViewCell>
                     <StackLayout Orientation="Horizontal"
                                  VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
-                                 Margin="12,0,12,0">                    
+                                 Margin="12,0,12,0">
                         <Label Text="{Binding Description}" VerticalOptions="Center" HorizontalOptions="Start" />
                     </StackLayout>
                 </ViewCell>
@@ -35,7 +35,7 @@
                 <ViewCell>
                     <StackLayout Orientation="Horizontal"
                                  VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
-                                 Margin="12,0,12,0">                    
+                                 Margin="12,0,12,0">
                         <Label Text="{Binding Description}" VerticalOptions="Center" HorizontalOptions="Start" />
                     </StackLayout>
                 </ViewCell>
@@ -43,13 +43,13 @@
             <global:VersionInfoDataTemplateSelector x:Key="VersionInfoDataTemplateSelector"
                                                     HeaderTemplate="{StaticResource HeaderTemplate}"
                                                     FeatureTemplate="{StaticResource FeatureTemplate}"
-                                                    BugFixTemplate="{StaticResource BugFixTemplate}" />            
+                                                    BugFixTemplate="{StaticResource BugFixTemplate}" />
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.BindingContext>
         <viewModels:IndexViewModel />
     </ContentPage.BindingContext>
-    
+
     <ContentPage.Content>
         <ListView x:Name="VersionsList"
                   ItemsSource="{Binding Versions}"

--- a/Xappy/Xappy/Content/Settings/SettingsPages.xaml.cs
+++ b/Xappy/Xappy/Content/Settings/SettingsPages.xaml.cs
@@ -16,9 +16,10 @@ namespace Xappy.Content.Settings
             InitializeComponent();
         }
 
-        async void Handle_CloseClicked(object sender, System.EventArgs e)
+        void Handle_CloseClicked(object sender, System.EventArgs e)
         {
-            await Shell.Current.Navigation.PopModalAsync();
+            //awaiting this causes a crash in android
+            Shell.Current.Navigation.PopModalAsync();
         }
 
         void Handle_Clicked(object sender, System.EventArgs e)


### PR DESCRIPTION
1) Navigating to the About page 

Xamarin.Forms.Xaml.XamlParseException: Position 9:14. StaticResource not found for key ColorAppBackground
StaticResourceExtension.GetApplicationLevelResource (System.String key, System.Xml.IXmlLineInfo xmlLineInfo)
StaticResourceExtension.ProvideValue (System.IServiceProvider serviceProvider)
IndexPage.InitializeComponent ()
Xappy.About.IndexPage..ctor () [0x00008] in <a018432961ae45a5a66f8584ef80f2eb>:0
(wrapper managed-to-native) System.Reflection.RuntimeConstructorInfo.InternalInvoke(System.Reflection.RuntimeConstructorInfo,object,object[],System.Exception&)
RuntimeConstructorInfo.InternalInvoke (System.Object obj, System.Object[] parameters, System.Boolean wrapExceptions)

2) Awaiting the closure of the settings modal

System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. Parameter name: index
List`1[T].get_Item (System.Int32 index)
Application+NavigationImpl.OnPopModal (System.Boolean animated) D:\a\1\s\Xamarin.Forms.Core\Application.cs:374
SettingsPages.Handle_CloseClicked (System.Object sender, System.EventArgs e) C:\Users\RobinSchroeder\source\repos\Xappy\Xappy\Xappy\Content\Settings\SettingsPages.xaml.cs:41
AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state)
SyncContext+<>c__DisplayClass2_0.<Post>b__0 ()
Thread+RunnableImplementor.Run ()
IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this)