### PR TITLE
Update to fix project loading issue in VS

### DIFF
--- a/Xappy/Xappy.iOS/Xappy.iOS.csproj
+++ b/Xappy/Xappy.iOS/Xappy.iOS.csproj
@@ -173,6 +173,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Assets.xcassets\MicrosoftLogo.imageset\" />
+  </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\guitar3.jpg" />
   </ItemGroup>


### PR DESCRIPTION
One of ItemGroup tags wasn't closed causing project can't be opened in Visual Studio.