### PR TITLE
hotfix: smooth shell flyout render

### DIFF
--- a/Xappy/Xappy.Android/Resources/Resource.designer.cs
+++ b/Xappy/Xappy.Android/Resources/Resource.designer.cs
@@ -29000,422 +29000,206 @@ namespace Xappy.Droid
 			// aapt resource value: 0x7F070065
 			public const int btn_radio_on_to_off_mtrl_animation = 2131165285;
 			
-			// aapt resource value: 0x7F07006B
-			public const int cell_entrycell = 2131165291;
-			
 			// aapt resource value: 0x7F070066
-			public const int cell_EntryCell = 2131165286;
+			public const int common_full_open_on_phone = 2131165286;
 			
 			// aapt resource value: 0x7F070067
-			public const int cell_ImageCell = 2131165287;
-			
-			// aapt resource value: 0x7F07006C
-			public const int cell_imagecell = 2131165292;
+			public const int common_google_signin_btn_icon_dark = 2131165287;
 			
 			// aapt resource value: 0x7F070068
-			public const int cell_SwitchCell = 2131165288;
-			
-			// aapt resource value: 0x7F07006D
-			public const int cell_switchcell = 2131165293;
+			public const int common_google_signin_btn_icon_dark_focused = 2131165288;
 			
 			// aapt resource value: 0x7F070069
-			public const int cell_TextCell = 2131165289;
-			
-			// aapt resource value: 0x7F07006E
-			public const int cell_textcell = 2131165294;
+			public const int common_google_signin_btn_icon_dark_normal = 2131165289;
 			
 			// aapt resource value: 0x7F07006A
-			public const int cell_ViewCell = 2131165290;
+			public const int common_google_signin_btn_icon_dark_normal_background = 2131165290;
+			
+			// aapt resource value: 0x7F07006B
+			public const int common_google_signin_btn_icon_disabled = 2131165291;
+			
+			// aapt resource value: 0x7F07006C
+			public const int common_google_signin_btn_icon_light = 2131165292;
+			
+			// aapt resource value: 0x7F07006D
+			public const int common_google_signin_btn_icon_light_focused = 2131165293;
+			
+			// aapt resource value: 0x7F07006E
+			public const int common_google_signin_btn_icon_light_normal = 2131165294;
 			
 			// aapt resource value: 0x7F07006F
-			public const int cell_viewcell = 2131165295;
+			public const int common_google_signin_btn_icon_light_normal_background = 2131165295;
 			
 			// aapt resource value: 0x7F070070
-			public const int common_full_open_on_phone = 2131165296;
+			public const int common_google_signin_btn_text_dark = 2131165296;
 			
 			// aapt resource value: 0x7F070071
-			public const int common_google_signin_btn_icon_dark = 2131165297;
+			public const int common_google_signin_btn_text_dark_focused = 2131165297;
 			
 			// aapt resource value: 0x7F070072
-			public const int common_google_signin_btn_icon_dark_focused = 2131165298;
+			public const int common_google_signin_btn_text_dark_normal = 2131165298;
 			
 			// aapt resource value: 0x7F070073
-			public const int common_google_signin_btn_icon_dark_normal = 2131165299;
+			public const int common_google_signin_btn_text_dark_normal_background = 2131165299;
 			
 			// aapt resource value: 0x7F070074
-			public const int common_google_signin_btn_icon_dark_normal_background = 2131165300;
+			public const int common_google_signin_btn_text_disabled = 2131165300;
 			
 			// aapt resource value: 0x7F070075
-			public const int common_google_signin_btn_icon_disabled = 2131165301;
+			public const int common_google_signin_btn_text_light = 2131165301;
 			
 			// aapt resource value: 0x7F070076
-			public const int common_google_signin_btn_icon_light = 2131165302;
+			public const int common_google_signin_btn_text_light_focused = 2131165302;
 			
 			// aapt resource value: 0x7F070077
-			public const int common_google_signin_btn_icon_light_focused = 2131165303;
+			public const int common_google_signin_btn_text_light_normal = 2131165303;
 			
 			// aapt resource value: 0x7F070078
-			public const int common_google_signin_btn_icon_light_normal = 2131165304;
+			public const int common_google_signin_btn_text_light_normal_background = 2131165304;
 			
 			// aapt resource value: 0x7F070079
-			public const int common_google_signin_btn_icon_light_normal_background = 2131165305;
+			public const int design_bottom_navigation_item_background = 2131165305;
 			
 			// aapt resource value: 0x7F07007A
-			public const int common_google_signin_btn_text_dark = 2131165306;
+			public const int design_fab_background = 2131165306;
 			
 			// aapt resource value: 0x7F07007B
-			public const int common_google_signin_btn_text_dark_focused = 2131165307;
+			public const int design_ic_visibility = 2131165307;
 			
 			// aapt resource value: 0x7F07007C
-			public const int common_google_signin_btn_text_dark_normal = 2131165308;
+			public const int design_ic_visibility_off = 2131165308;
 			
 			// aapt resource value: 0x7F07007D
-			public const int common_google_signin_btn_text_dark_normal_background = 2131165309;
+			public const int design_password_eye = 2131165309;
 			
 			// aapt resource value: 0x7F07007E
-			public const int common_google_signin_btn_text_disabled = 2131165310;
+			public const int design_snackbar_background = 2131165310;
 			
 			// aapt resource value: 0x7F07007F
-			public const int common_google_signin_btn_text_light = 2131165311;
+			public const int googleg_disabled_color_18 = 2131165311;
 			
 			// aapt resource value: 0x7F070080
-			public const int common_google_signin_btn_text_light_focused = 2131165312;
+			public const int googleg_standard_color_18 = 2131165312;
 			
 			// aapt resource value: 0x7F070081
-			public const int common_google_signin_btn_text_light_normal = 2131165313;
+			public const int ic_mtrl_checked_circle = 2131165313;
 			
 			// aapt resource value: 0x7F070082
-			public const int common_google_signin_btn_text_light_normal_background = 2131165314;
+			public const int ic_mtrl_chip_checked_black = 2131165314;
 			
 			// aapt resource value: 0x7F070083
-			public const int design_bottom_navigation_item_background = 2131165315;
+			public const int ic_mtrl_chip_checked_circle = 2131165315;
 			
 			// aapt resource value: 0x7F070084
-			public const int design_fab_background = 2131165316;
+			public const int ic_mtrl_chip_close_circle = 2131165316;
 			
 			// aapt resource value: 0x7F070085
-			public const int design_ic_visibility = 2131165317;
-			
-			// aapt resource value: 0x7F070086
-			public const int design_ic_visibility_off = 2131165318;
-			
-			// aapt resource value: 0x7F070087
-			public const int design_password_eye = 2131165319;
-			
-			// aapt resource value: 0x7F070088
-			public const int design_snackbar_background = 2131165320;
-			
-			// aapt resource value: 0x7F070089
-			public const int googleg_disabled_color_18 = 2131165321;
-			
-			// aapt resource value: 0x7F07008A
-			public const int googleg_standard_color_18 = 2131165322;
-			
-			// aapt resource value: 0x7F07008B
-			public const int guitar1 = 2131165323;
-			
-			// aapt resource value: 0x7F07008C
-			public const int guitar2 = 2131165324;
+			public const int launch_screen = 2131165317;
 			
 			// aapt resource value: 0x7F07008D
-			public const int guitar3 = 2131165325;
+			public const int MaterialActivityIndicatorBackground = 2131165325;
 			
 			// aapt resource value: 0x7F07008E
-			public const int ic_mtrl_checked_circle = 2131165326;
+			public const int MaterialProgressBar = 2131165326;
+			
+			// aapt resource value: 0x7F070086
+			public const int material_ic_calendar_black_24dp = 2131165318;
+			
+			// aapt resource value: 0x7F070087
+			public const int material_ic_clear_black_24dp = 2131165319;
+			
+			// aapt resource value: 0x7F070088
+			public const int material_ic_edit_black_24dp = 2131165320;
+			
+			// aapt resource value: 0x7F070089
+			public const int material_ic_keyboard_arrow_left_black_24dp = 2131165321;
+			
+			// aapt resource value: 0x7F07008A
+			public const int material_ic_keyboard_arrow_right_black_24dp = 2131165322;
+			
+			// aapt resource value: 0x7F07008B
+			public const int material_ic_menu_arrow_down_black_24dp = 2131165323;
+			
+			// aapt resource value: 0x7F07008C
+			public const int material_ic_menu_arrow_up_black_24dp = 2131165324;
 			
 			// aapt resource value: 0x7F07008F
-			public const int ic_mtrl_chip_checked_black = 2131165327;
+			public const int mtrl_dialog_background = 2131165327;
 			
 			// aapt resource value: 0x7F070090
-			public const int ic_mtrl_chip_checked_circle = 2131165328;
+			public const int mtrl_dropdown_arrow = 2131165328;
 			
 			// aapt resource value: 0x7F070091
-			public const int ic_mtrl_chip_close_circle = 2131165329;
+			public const int mtrl_ic_arrow_drop_down = 2131165329;
 			
 			// aapt resource value: 0x7F070092
-			public const int launch_screen = 2131165330;
-			
-			// aapt resource value: 0x7F0700A2
-			public const int layoutstacklayout = 2131165346;
+			public const int mtrl_ic_arrow_drop_up = 2131165330;
 			
 			// aapt resource value: 0x7F070093
-			public const int layout_AbsoluteLayout = 2131165331;
-			
-			// aapt resource value: 0x7F07009A
-			public const int layout_absolutelayout = 2131165338;
+			public const int mtrl_ic_cancel = 2131165331;
 			
 			// aapt resource value: 0x7F070094
-			public const int layout_ContentView = 2131165332;
-			
-			// aapt resource value: 0x7F07009B
-			public const int layout_contentview = 2131165339;
+			public const int mtrl_ic_error = 2131165332;
 			
 			// aapt resource value: 0x7F070095
-			public const int layout_FlexLayout = 2131165333;
-			
-			// aapt resource value: 0x7F07009C
-			public const int layout_flexlayout = 2131165340;
-			
-			// aapt resource value: 0x7F07009D
-			public const int layout_frame = 2131165341;
+			public const int mtrl_popupmenu_background = 2131165333;
 			
 			// aapt resource value: 0x7F070096
-			public const int layout_Frame = 2131165334;
-			
-			// aapt resource value: 0x7F07009E
-			public const int layout_grid = 2131165342;
+			public const int mtrl_popupmenu_background_dark = 2131165334;
 			
 			// aapt resource value: 0x7F070097
-			public const int layout_Grid = 2131165335;
+			public const int mtrl_tabs_default_indicator = 2131165335;
 			
 			// aapt resource value: 0x7F070098
-			public const int layout_RelativeLayout = 2131165336;
-			
-			// aapt resource value: 0x7F07009F
-			public const int layout_relativelayout = 2131165343;
-			
-			// aapt resource value: 0x7F0700A0
-			public const int layout_scrollview = 2131165344;
+			public const int navigation_empty_icon = 2131165336;
 			
 			// aapt resource value: 0x7F070099
-			public const int layout_ScrollView = 2131165337;
+			public const int notification_action_background = 2131165337;
+			
+			// aapt resource value: 0x7F07009A
+			public const int notification_bg = 2131165338;
+			
+			// aapt resource value: 0x7F07009B
+			public const int notification_bg_low = 2131165339;
+			
+			// aapt resource value: 0x7F07009C
+			public const int notification_bg_low_normal = 2131165340;
+			
+			// aapt resource value: 0x7F07009D
+			public const int notification_bg_low_pressed = 2131165341;
+			
+			// aapt resource value: 0x7F07009E
+			public const int notification_bg_normal = 2131165342;
+			
+			// aapt resource value: 0x7F07009F
+			public const int notification_bg_normal_pressed = 2131165343;
+			
+			// aapt resource value: 0x7F0700A0
+			public const int notification_icon_background = 2131165344;
 			
 			// aapt resource value: 0x7F0700A1
-			public const int layout_stacklayout = 2131165345;
+			public const int notification_template_icon_bg = 2131165345;
 			
-			// aapt resource value: 0x7F0700AA
-			public const int MaterialActivityIndicatorBackground = 2131165354;
-			
-			// aapt resource value: 0x7F0700AB
-			public const int MaterialProgressBar = 2131165355;
+			// aapt resource value: 0x7F0700A2
+			public const int notification_template_icon_low_bg = 2131165346;
 			
 			// aapt resource value: 0x7F0700A3
-			public const int material_ic_calendar_black_24dp = 2131165347;
+			public const int notification_tile_bg = 2131165347;
 			
 			// aapt resource value: 0x7F0700A4
-			public const int material_ic_clear_black_24dp = 2131165348;
+			public const int notify_panel_notification_icon_bg = 2131165348;
 			
 			// aapt resource value: 0x7F0700A5
-			public const int material_ic_edit_black_24dp = 2131165349;
+			public const int test_custom_background = 2131165349;
 			
 			// aapt resource value: 0x7F0700A6
-			public const int material_ic_keyboard_arrow_left_black_24dp = 2131165350;
+			public const int tooltip_frame_dark = 2131165350;
 			
 			// aapt resource value: 0x7F0700A7
-			public const int material_ic_keyboard_arrow_right_black_24dp = 2131165351;
+			public const int tooltip_frame_light = 2131165351;
 			
 			// aapt resource value: 0x7F0700A8
-			public const int material_ic_menu_arrow_down_black_24dp = 2131165352;
-			
-			// aapt resource value: 0x7F0700A9
-			public const int material_ic_menu_arrow_up_black_24dp = 2131165353;
-			
-			// aapt resource value: 0x7F0700AC
-			public const int menu = 2131165356;
-			
-			// aapt resource value: 0x7F0700AD
-			public const int mtrl_dialog_background = 2131165357;
-			
-			// aapt resource value: 0x7F0700AE
-			public const int mtrl_dropdown_arrow = 2131165358;
-			
-			// aapt resource value: 0x7F0700AF
-			public const int mtrl_ic_arrow_drop_down = 2131165359;
-			
-			// aapt resource value: 0x7F0700B0
-			public const int mtrl_ic_arrow_drop_up = 2131165360;
-			
-			// aapt resource value: 0x7F0700B1
-			public const int mtrl_ic_cancel = 2131165361;
-			
-			// aapt resource value: 0x7F0700B2
-			public const int mtrl_ic_error = 2131165362;
-			
-			// aapt resource value: 0x7F0700B3
-			public const int mtrl_popupmenu_background = 2131165363;
-			
-			// aapt resource value: 0x7F0700B4
-			public const int mtrl_popupmenu_background_dark = 2131165364;
-			
-			// aapt resource value: 0x7F0700B5
-			public const int mtrl_tabs_default_indicator = 2131165365;
-			
-			// aapt resource value: 0x7F0700B6
-			public const int navigation_empty_icon = 2131165366;
-			
-			// aapt resource value: 0x7F0700B7
-			public const int notification_action_background = 2131165367;
-			
-			// aapt resource value: 0x7F0700B8
-			public const int notification_bg = 2131165368;
-			
-			// aapt resource value: 0x7F0700B9
-			public const int notification_bg_low = 2131165369;
-			
-			// aapt resource value: 0x7F0700BA
-			public const int notification_bg_low_normal = 2131165370;
-			
-			// aapt resource value: 0x7F0700BB
-			public const int notification_bg_low_pressed = 2131165371;
-			
-			// aapt resource value: 0x7F0700BC
-			public const int notification_bg_normal = 2131165372;
-			
-			// aapt resource value: 0x7F0700BD
-			public const int notification_bg_normal_pressed = 2131165373;
-			
-			// aapt resource value: 0x7F0700BE
-			public const int notification_icon_background = 2131165374;
-			
-			// aapt resource value: 0x7F0700BF
-			public const int notification_template_icon_bg = 2131165375;
-			
-			// aapt resource value: 0x7F0700C0
-			public const int notification_template_icon_low_bg = 2131165376;
-			
-			// aapt resource value: 0x7F0700C1
-			public const int notification_tile_bg = 2131165377;
-			
-			// aapt resource value: 0x7F0700C2
-			public const int notify_panel_notification_icon_bg = 2131165378;
-			
-			// aapt resource value: 0x7F0700C3
-			public const int on01 = 2131165379;
-			
-			// aapt resource value: 0x7F0700C4
-			public const int on02 = 2131165380;
-			
-			// aapt resource value: 0x7F0700C5
-			public const int on03 = 2131165381;
-			
-			// aapt resource value: 0x7F0700C6
-			public const int test_custom_background = 2131165382;
-			
-			// aapt resource value: 0x7F0700C7
-			public const int tooltip_frame_dark = 2131165383;
-			
-			// aapt resource value: 0x7F0700C8
-			public const int tooltip_frame_light = 2131165384;
-			
-			// aapt resource value: 0x7F0700C9
-			public const int view_ActivityIndicator = 2131165385;
-			
-			// aapt resource value: 0x7F0700DC
-			public const int view_activityindicator = 2131165404;
-			
-			// aapt resource value: 0x7F0700CA
-			public const int view_BoxView = 2131165386;
-			
-			// aapt resource value: 0x7F0700DD
-			public const int view_boxview = 2131165405;
-			
-			// aapt resource value: 0x7F0700DE
-			public const int view_button = 2131165406;
-			
-			// aapt resource value: 0x7F0700CB
-			public const int view_Button = 2131165387;
-			
-			// aapt resource value: 0x7F0700DF
-			public const int view_datepicker = 2131165407;
-			
-			// aapt resource value: 0x7F0700CC
-			public const int view_DatePicker = 2131165388;
-			
-			// aapt resource value: 0x7F0700CD
-			public const int view_Editor = 2131165389;
-			
-			// aapt resource value: 0x7F0700E0
-			public const int view_editor = 2131165408;
-			
-			// aapt resource value: 0x7F0700CE
-			public const int view_Entry = 2131165390;
-			
-			// aapt resource value: 0x7F0700E1
-			public const int view_entry = 2131165409;
-			
-			// aapt resource value: 0x7F0700CF
-			public const int view_Image = 2131165391;
-			
-			// aapt resource value: 0x7F0700E2
-			public const int view_image = 2131165410;
-			
-			// aapt resource value: 0x7F0700D0
-			public const int view_Label = 2131165392;
-			
-			// aapt resource value: 0x7F0700E3
-			public const int view_label = 2131165411;
-			
-			// aapt resource value: 0x7F0700E4
-			public const int view_listview = 2131165412;
-			
-			// aapt resource value: 0x7F0700D1
-			public const int view_ListView = 2131165393;
-			
-			// aapt resource value: 0x7F0700D2
-			public const int view_Map = 2131165394;
-			
-			// aapt resource value: 0x7F0700E5
-			public const int view_map = 2131165413;
-			
-			// aapt resource value: 0x7F0700E6
-			public const int view_picker = 2131165414;
-			
-			// aapt resource value: 0x7F0700D3
-			public const int view_Picker = 2131165395;
-			
-			// aapt resource value: 0x7F0700E7
-			public const int view_progressbar = 2131165415;
-			
-			// aapt resource value: 0x7F0700D4
-			public const int view_ProgressBar = 2131165396;
-			
-			// aapt resource value: 0x7F0700D5
-			public const int view_SearchBar = 2131165397;
-			
-			// aapt resource value: 0x7F0700E8
-			public const int view_searchbar = 2131165416;
-			
-			// aapt resource value: 0x7F0700D6
-			public const int view_Slider = 2131165398;
-			
-			// aapt resource value: 0x7F0700E9
-			public const int view_slider = 2131165417;
-			
-			// aapt resource value: 0x7F0700D7
-			public const int view_Stepper = 2131165399;
-			
-			// aapt resource value: 0x7F0700EA
-			public const int view_stepper = 2131165418;
-			
-			// aapt resource value: 0x7F0700D8
-			public const int view_Switch = 2131165400;
-			
-			// aapt resource value: 0x7F0700EB
-			public const int view_switch = 2131165419;
-			
-			// aapt resource value: 0x7F0700D9
-			public const int view_TableView = 2131165401;
-			
-			// aapt resource value: 0x7F0700EC
-			public const int view_tableview = 2131165420;
-			
-			// aapt resource value: 0x7F0700ED
-			public const int view_timepicker = 2131165421;
-			
-			// aapt resource value: 0x7F0700DA
-			public const int view_TimePicker = 2131165402;
-			
-			// aapt resource value: 0x7F0700EE
-			public const int view_webview = 2131165422;
-			
-			// aapt resource value: 0x7F0700DB
-			public const int view_WebView = 2131165403;
-			
-			// aapt resource value: 0x7F0700EF
-			public const int xamagon_preview = 2131165423;
-			
-			// aapt resource value: 0x7F0700F0
-			public const int xamarin_forms_ui = 2131165424;
+			public const int xamagon_preview = 2131165352;
 			
 			static Drawable()
 			{

--- a/Xappy/Xappy.Android/Xappy.Android.csproj
+++ b/Xappy/Xappy.Android/Xappy.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
When we tap on the shell flyout item, it closes and navigates but if you notice when navigating the shell flyout lags before navigation. This PR fixes that problem.